### PR TITLE
Update RoyaltiesRegistry.sol

### DIFF
--- a/royalties-registry/contracts/RoyaltiesRegistry.sol
+++ b/royalties-registry/contracts/RoyaltiesRegistry.sol
@@ -91,7 +91,7 @@ contract RoyaltiesRegistry is IRoyaltiesProvider, OwnableUpgradeable {
 			try withFees.getRoyalties(tokenId) returns (LibPart.Part[] memory feesRecipientsResult) {
 				return feesRecipientsResult;
 			} catch {}
-		} else if (IERC165Upgradeable(token).supportsInterface(LibRoyaltiesV1._INTERFACE_ID_FEES)) {
+		} else {
 			RoyaltiesV1Impl withFees = RoyaltiesV1Impl(token);
 			address payable[] memory recipients;
 			try withFees.getFeeRecipients(tokenId) returns (address payable[] memory recipientsResult) {


### PR DESCRIPTION
Do not do an IERC165 check, but rather just call getFeeRecipients and getFeeBps.
Rationale:
1. It is cheaper gas wise to simply call the function and have it fail than to do the IERC165 check first
2. There are a few contracts out there that implement getFeeReceipients and getFeeBps without implementing IERC165