### PR TITLE
Update RoyaltiesRegistry.sol

### DIFF
--- a/royalties-registry/contracts/RoyaltiesRegistry.sol
+++ b/royalties-registry/contracts/RoyaltiesRegistry.sol
@@ -98,7 +98,7 @@ contract RoyaltiesRegistry is IRoyaltiesProvider, OwnableUpgradeable {
             try v2.getRoyalties(tokenId) returns (LibPart.Part[] memory result) {
                 return result;
             } catch {}
-        } else if (IERC165Upgradeable(token).supportsInterface(LibRoyaltiesV1._INTERFACE_ID_FEES)) {
+        } else {
             RoyaltiesV1 v1 = RoyaltiesV1(token);
             address payable[] memory recipients;
             try v1.getFeeRecipients(tokenId) returns (address payable[] memory result) {


### PR DESCRIPTION
Do not do an IERC165 check, but rather just call getFeeRecipients and getFeeBps.
Rationale:

It is cheaper gas wise to simply call the function and have it fail than to do the IERC165 check first
There are a few contracts out there that implement getFeeReceipients and getFeeBps without implementing IERC165