### PR TITLE
Staking optimization

### DIFF
--- a/broken-line/contracts/LibBrokenLine.sol
+++ b/broken-line/contracts/LibBrokenLine.sol
@@ -119,16 +119,18 @@ library LibBrokenLine {
         if (time == toTime) {
             return;
         }
-        uint bias = brokenLine.initial.bias;
         uint slope = brokenLine.initial.slope;
-        require(toTime > time, "can't update BrokenLine for past time");
-        while (time < toTime) {
-            bias = bias.sub(slope);
-            int newSlope = safeInt(slope).add(brokenLine.slopeChanges[time]);
-            require(newSlope >= 0, "slope < 0, something wrong with slope");
-            slope = uint(newSlope);
-            brokenLine.slopeChanges[time] = 0;
-            time = time.add(1);
+        uint bias = brokenLine.initial.bias;
+        if (bias != 0) {
+            require(toTime > time, "can't update BrokenLine for past time");
+            while (time < toTime) {
+                bias = bias.sub(slope);
+                int newSlope = safeInt(slope).add(brokenLine.slopeChanges[time]);
+                require(newSlope >= 0, "slope < 0, something wrong with slope");
+                slope = uint(newSlope);
+                brokenLine.slopeChanges[time] = 0;
+                time = time.add(1);
+            }
         }
         brokenLine.initial.start = toTime;
         brokenLine.initial.bias = bias;
@@ -137,10 +139,10 @@ library LibBrokenLine {
 
     function actualValue(BrokenLine storage brokenLine, uint toTime) internal view returns (uint bias) {
         uint time = brokenLine.initial.start;
-        if (time == toTime) {
-            return (brokenLine.initial.bias);
-        }
         bias = brokenLine.initial.bias;
+        if ((time == toTime) || (bias == 0)){
+            return (bias);
+        }
         uint slope = brokenLine.initial.slope;
         require(toTime > time, "can't update BrokenLine for past time");
         while (time < toTime) {

--- a/staking/contracts/Staking.sol
+++ b/staking/contracts/Staking.sol
@@ -43,7 +43,7 @@ contract Staking is StakingBase, StakingRestake {
     }
 
     function withdraw() external {
-        uint value = getAvailableForWithdraw();
+        uint value = getAvailableForWithdraw(msg.sender);
         if (value > 0) {
             accounts[msg.sender].amount = accounts[msg.sender].amount.sub(value);
             require(token.transfer(msg.sender, value), "transfer failed");
@@ -52,18 +52,18 @@ contract Staking is StakingBase, StakingRestake {
     }
 
     // Amount available for withdrawal
-    function getAvailableForWithdraw() public view returns (uint value) {
-        value = accounts[msg.sender].amount;
+    function getAvailableForWithdraw(address account) public view returns (uint value) {
+        value = accounts[account].amount;
         if (!stopped) {
             uint time = roundTimestamp(block.timestamp);
-            uint bias = accounts[msg.sender].locked.actualValue(time);
+            uint bias = accounts[account].locked.actualValue(time);
             value = value.sub(bias);
         }
     }
 
     //Remaining locked amount
-    function locked() external view returns (uint) {
-        return accounts[msg.sender].amount;
+    function locked(address account) external view returns (uint) {
+        return accounts[account].amount;
     }
 
     //For a given Line id, the owner and delegate addresses.

--- a/staking/test/Staking.test.js
+++ b/staking/test/Staking.test.js
@@ -74,10 +74,10 @@ contract("Staking", accounts => {
    		await token.approve(staking.address, 1000000, { from: accounts[2] });
       await staking.stake(accounts[2], accounts[2], 85, 10, 0, { from: accounts[2] });
 
-			let lockedValue = await staking.locked.call({ from: accounts[2] });
+			let lockedValue = await staking.locked.call(accounts[2]);
    		assert.equal(lockedValue, 85);			//locked from: accounts[2]
 
-			lockedValue = await staking.locked.call({ from: accounts[3] });
+			lockedValue = await staking.locked.call(accounts[3]);
    		assert.equal(lockedValue, 0);			//locked from: accounts[3]
 		});
 
@@ -87,7 +87,7 @@ contract("Staking", accounts => {
       await staking.stake(accounts[2], accounts[2], 30, 10, 0, { from: accounts[2] });
 			/*3 week later*/
 			await increaseTime(WEEK * 2);
-			let availableForWithdraw = await staking.getAvailableForWithdraw.call({ from: accounts[2] });
+			let availableForWithdraw = await staking.getAvailableForWithdraw.call(accounts[2]);
  			assert.equal(await token.balanceOf(staking.address), 30);	//balance Lock on deposite
    		assert.equal(await token.balanceOf(accounts[2]), 70);			//tail user balance
    		assert.equal(availableForWithdraw, 20);			//availableForWithdraw after 2 weeks

--- a/tokens/readme.md
+++ b/tokens/readme.md
@@ -26,7 +26,7 @@ For ERC-721 function has following signature: `mintAndTransfer(LibERC721LazyMint
 ```
     struct Mint721Data {
         uint tokenId;
-        string uri;
+        string tokenURI;
         address[] creators;
         LibPart.Part[] royalties;
         bytes[] signatures;
@@ -34,9 +34,9 @@ For ERC-721 function has following signature: `mintAndTransfer(LibERC721LazyMint
 ```  
 
 - **tokenId** - regular ERC-721 tokenId
-- **uri** - suffix for the token uri. prefix is usually "ipfs:/"
+- **tokenURI** - suffix for the token uri. prefix is usually "ipfs:/"
 - **creators** - array of addresses who considered authors of the work. Will be saved, anyone can query this info.
-- **fees** - array of royalties, will be saved. . Will be saved, anyone can query this info.
+- **royalties** - array of royalties, will be saved. . Will be saved, anyone can query this info.
 - **signatures** - array of signatures of this information. Signature should be present for every creator (only exception is when creator sends mint transaction)
 
 For ERC-1155 function has some more arguments: `mintAndTransfer(LibERC1155LazyMint.Mint1155Data memory data, address to, uint256 _amount)`
@@ -44,7 +44,7 @@ For ERC-1155 function has some more arguments: `mintAndTransfer(LibERC1155LazyMi
 ```
     struct Mint1155Data {
         uint tokenId;
-        string uri;
+        string tokenURI;
         uint supply;
         address[] creators;
         LibPart.Part[] royalties;
@@ -53,10 +53,10 @@ For ERC-1155 function has some more arguments: `mintAndTransfer(LibERC1155LazyMi
 ```
 
 - **tokenId** - ERC-1155 tokenId
-- **uri** - suffix for the token uri. prefix is usually "ipfs:/"
+- **tokenURI** - suffix for the token uri. prefix is usually "ipfs:/"
 - **supply** - total supply for tokenId. can not be changed after initial mint.
 - **creators** - array of addresses who considered authors of the work. Will be saved, anyone can query this info.
-- **fees** - array of royalties, will be saved. . Will be saved, anyone can query this info.
+- **royalties** - array of royalties, will be saved. . Will be saved, anyone can query this info.
 - **signatures** - array of signatures of this information. Signature should be present for every creator (only exception is when creator sends mint transaction)
 
 mintAndTransfer for ERC-1155 can be called multiple times until total minted amount is not equal to supply.


### PR DESCRIPTION
Some stake optimization, after contract review
Points:
1) 5.7 - some getters are msg.sender specific. Depending on where and how you want to use it, that might be fine. But for more general usage, passing an address like in balanceOf(address) is more general solution.
2) I noticed that current way the libBroken works is iterating from 0 to  time for any new line. In future, the gas needed to create a new line will rise significantly, because the loop still always starts from 0.
Can't you distinguish between brokenLine.initial.bias==0 case and just assign the new values without looping?